### PR TITLE
Add n8n Webhook Debug Set Node Configuration

### DIFF
--- a/docs/n8n-webhook-debug-set-node.json
+++ b/docs/n8n-webhook-debug-set-node.json
@@ -1,0 +1,54 @@
+{
+  "name": "Debug Webhook Data",
+  "type": "n8n-nodes-base.set",
+  "typeVersion": 3.4,
+  "position": [
+    500,
+    200
+  ],
+  "parameters": {
+    "mode": "manual",
+    "includeOtherFields": true,
+    "assignments": {
+      "assignments": [
+        {
+          "id": "webhook-data",
+          "name": "webhookData", 
+          "value": "={{ $input.item.json }}",
+          "type": "object"
+        },
+        {
+          "id": "all-nodes",
+          "name": "allNodes",
+          "value": "={{ Object.keys($node) }}",
+          "type": "object"
+        },
+        {
+          "id": "webhook-specific",
+          "name": "webhookSpecific",
+          "value": "={{ $node['Webhook']?.json || 'Webhook node not found' }}",
+          "type": "object"
+        },
+        {
+          "id": "webhook-items",
+          "name": "webhookItems", 
+          "value": "={{ $items('Webhook')?.[0]?.json || 'No webhook items found' }}",
+          "type": "object"
+        },
+        {
+          "id": "current-json",
+          "name": "currentJson",
+          "value": "={{ $json }}",
+          "type": "object"
+        },
+        {
+          "id": "debug-info",
+          "name": "debugInfo",
+          "value": "={{ { timestamp: $now.toISO(), nodeCount: Object.keys($node).length, dataKeys: Object.keys($input.item.json || {}) } }}",
+          "type": "object"
+        }
+      ]
+    },
+    "options": {}
+  }
+}


### PR DESCRIPTION
## 🔧 n8n Webhook Debug Set Node Configuration

This PR adds a comprehensive debugging configuration for n8n webhook workflows based on Claude Code's analysis and recommendations.

### 🎯 **What This Solves**
- Debugging "Respond to Webhook" node issues with `[Referenced node doesn't exist]` and `[undefined]` errors
- Understanding what data is available from webhook triggers
- Proper n8n expression syntax for accessing webhook data

### 📋 **What's Included**
A ready-to-use Set node configuration (`docs/n8n-webhook-debug-set-node.json`) that captures:

1. **webhookData** - `$input.item.json` - Current input data
2. **allNodes** - `Object.keys($node)` - All available node names  
3. **webhookSpecific** - `$node['Webhook'].json` - Direct webhook node data
4. **webhookItems** - `$items('Webhook')[0].json` - First webhook item
5. **currentJson** - `$json` - Current node JSON data
6. **debugInfo** - Metadata with timestamp, node count, and data keys

### 🚀 **Usage Instructions**
1. Copy the JSON configuration from `docs/n8n-webhook-debug-set-node.json`
2. Add a **Set** node to your n8n workflow after the **Webhook Trigger**
3. Paste this configuration into the Set node parameters
4. Execute the workflow to see all available webhook data structures
5. Use the output to fix your "Respond to Webhook" node expressions

### ✅ **Expected Results**
After adding this debug node, you'll see exactly:
- What data your webhook receives
- How to properly reference webhook data in other nodes
- Which node names are available for `$node['NodeName']` syntax
- The correct field names and data structure

### 🔗 **Related Issues**
- Fixes webhook integration debugging challenges
- Resolves "Invalid syntax" errors in Respond to Webhook nodes
- Provides foundation for frontend → n8n integration

This configuration is based on Claude Code's n8n expertise and has been validated against the official n8n documentation.